### PR TITLE
be consistent with nim, python, C , C++, go (etc) : Infinity => inf, NaN => nan, E => e

### DIFF
--- a/ryu/common.nim
+++ b/ryu/common.nim
@@ -82,11 +82,11 @@ proc log10Pow5*(e: int32): uint32 {.inline.} =
 
 proc specialStr*(sign, exponent, mantissa: bool): string {.inline.} =
   if mantissa:
-    result = "NaN"
+    result = "nan"
   elif exponent:
-    result = if sign: "-Infinity" else: "Infinity"
+    result = if sign: "-inf" else: "inf"
   else:
-    result = if sign: "-0E0" else: "0E0"
+    result = if sign: "-0e0" else: "0E0"
 
 proc copySpecialStr*(buff: var string; sign, exponent, mantissa: bool): int =
   buff = specialStr(sign, exponent, mantissa)

--- a/ryu/common.nim
+++ b/ryu/common.nim
@@ -86,7 +86,7 @@ proc specialStr*(sign, exponent, mantissa: bool): string {.inline.} =
   elif exponent:
     result = if sign: "-inf" else: "inf"
   else:
-    result = if sign: "-0e0" else: "0E0"
+    result = if sign: "-0e0" else: "0e0"
 
 proc copySpecialStr*(buff: var string; sign, exponent, mantissa: bool): int =
   buff = specialStr(sign, exponent, mantissa)

--- a/ryu/f2s.nim
+++ b/ryu/f2s.nim
@@ -419,7 +419,7 @@ proc toChars*(v: FloatingDecimal32; sign: bool): string {.inline.} =
     index.inc
 
   # Print the exponent.
-  result[index] = 'E'
+  result[index] = 'e'
   index.inc
 
   var

--- a/tests/tcommon.nim
+++ b/tests/tcommon.nim
@@ -61,16 +61,16 @@ suite "common test":
     check "nan" == buffer
     buffer = ""
 
-    check 8 == copySpecialStr(buffer, false, true, false)
+    check 3 == copySpecialStr(buffer, false, true, false)
     check "inf" == buffer
     buffer = ""
 
-    check 9 == copySpecialStr(buffer, true, true, false)
+    check 4 == copySpecialStr(buffer, true, true, false)
     check "-inf" == buffer
     buffer = ""
 
     check 4 == copySpecialStr(buffer, true, false, false)
-    check "-0E0" == buffer
+    check "-0e0" == buffer
     buffer = ""
 
   test "float_to_bits":

--- a/tests/tcommon.nim
+++ b/tests/tcommon.nim
@@ -58,15 +58,15 @@ suite "common test":
     var
       buffer: string
     check 3 == copySpecialStr(buffer, false, false, true)
-    check "NaN" == buffer
+    check "nan" == buffer
     buffer = ""
 
     check 8 == copySpecialStr(buffer, false, true, false)
-    check "Infinity" == buffer
+    check "inf" == buffer
     buffer = ""
 
     check 9 == copySpecialStr(buffer, true, true, false)
-    check "-Infinity" == buffer
+    check "-inf" == buffer
     buffer = ""
 
     check 4 == copySpecialStr(buffer, true, false, false)

--- a/tests/tf2s.nim
+++ b/tests/tf2s.nim
@@ -28,73 +28,73 @@ template ASSERT_F2S(s: string; f: float | float32 | float64) =
 
 suite "float to string":
   test "basic":
-    ASSERT_F2S("0E0", 0.0)
-    ASSERT_F2S("-0E0", -0.0)
-    ASSERT_F2S("1E0", 1.0)
-    ASSERT_F2S("-1E0", -1.0)
+    ASSERT_F2S("0e0", 0.0)
+    ASSERT_F2S("-0e0", -0.0)
+    ASSERT_F2S("1e0", 1.0)
+    ASSERT_F2S("-1e0", -1.0)
     ASSERT_F2S("nan", NAN)
     ASSERT_F2S("inf", 0.3 / 0.0)
     ASSERT_F2S("-inf", -0.3 / 0.0)
 
 
   test "switch to subnormal":
-    ASSERT_F2S("1.1754944E-38", 1.1754944E-38f)
+    ASSERT_F2S("1.1754944e-38", 1.1754944e-38f)
 
   test "min and max":
-    ASSERT_F2S("3.4028235E38", int32Bits2Float(0x7f7fffff))
-    ASSERT_F2S("1E-45", int32Bits2Float(1))
+    ASSERT_F2S("3.4028235e38", int32Bits2Float(0x7f7fffff))
+    ASSERT_F2S("1e-45", int32Bits2Float(1))
 
   # Check that we return the exact boundary if it is the shortest
   # representation, but only if the original floating point number is even.
   test "boundary round even":
-    ASSERT_F2S("3.355445E7", 3.355445E7f)
-    ASSERT_F2S("9E9", 8.999999E9f)
-    ASSERT_F2S("3.436672E10", 3.4366717E10f)
+    ASSERT_F2S("3.355445e7", 3.355445e7f)
+    ASSERT_F2S("9e9", 8.999999e9f)
+    ASSERT_F2S("3.436672e10", 3.4366717e10f)
 
   # If the exact value is exactly halfway between two shortest representations,
   # then we round to even. It seems like this only makes a difference if the
   # last two digits are ...2|5 or ...7|5, and we cut off the 5.
   test "extract value round even":
-    ASSERT_F2S("3.0540412E5", 3.0540412E5f)
-    ASSERT_F2S("8.0990312E3", 8.0990312E3f)
+    ASSERT_F2S("3.0540412e5", 3.0540412e5f)
+    ASSERT_F2S("8.0990312e3", 8.0990312e3f)
 
   test "lots of trailing zeros":
     # Pattern for the first test: 00111001100000000000000000000000
-    ASSERT_F2S("2.4414062E-4", 2.4414062E-4f)
-    ASSERT_F2S("2.4414062E-3", 2.4414062E-3f)
-    ASSERT_F2S("4.3945312E-3", 4.3945312E-3f)
-    ASSERT_F2S("6.3476562E-3", 6.3476562E-3f)
+    ASSERT_F2S("2.4414062e-4", 2.4414062e-4f)
+    ASSERT_F2S("2.4414062e-3", 2.4414062e-3f)
+    ASSERT_F2S("4.3945312e-3", 4.3945312e-3f)
+    ASSERT_F2S("6.3476562e-3", 6.3476562e-3f)
 
   test "regression":
-    ASSERT_F2S("4.7223665E21", 4.7223665E21f)
-    ASSERT_F2S("8.388608E6", 8388608.0f)
-    ASSERT_F2S("1.6777216E7", 1.6777216E7f)
-    ASSERT_F2S("3.3554436E7", 3.3554436E7f)
-    ASSERT_F2S("6.7131496E7", 6.7131496E7f)
-    ASSERT_F2S("1.9310392E-38", 1.9310392E-38f)
-    ASSERT_F2S("-2.47E-43", -2.47E-43f)
-    ASSERT_F2S("1.993244E-38", 1.993244E-38f)
-    ASSERT_F2S("4.1039004E3", 4103.9003f)
-    ASSERT_F2S("5.3399997E9", 5.3399997E9f)
-    ASSERT_F2S("6.0898E-39", 6.0898E-39f)
-    ASSERT_F2S("1.0310042E-3", 0.0010310042f)
-    ASSERT_F2S("2.882326E17", 2.8823261E17f)
+    ASSERT_F2S("4.7223665e21", 4.7223665e21f)
+    ASSERT_F2S("8.388608e6", 8388608.0f)
+    ASSERT_F2S("1.6777216e7", 1.6777216e7f)
+    ASSERT_F2S("3.3554436e7", 3.3554436e7f)
+    ASSERT_F2S("6.7131496e7", 6.7131496e7f)
+    ASSERT_F2S("1.9310392e-38", 1.9310392e-38f)
+    ASSERT_F2S("-2.47e-43", -2.47e-43f)
+    ASSERT_F2S("1.993244e-38", 1.993244e-38f)
+    ASSERT_F2S("4.1039004e3", 4103.9003f)
+    ASSERT_F2S("5.3399997e9", 5.3399997e9f)
+    ASSERT_F2S("6.0898e-39", 6.0898e-39f)
+    ASSERT_F2S("1.0310042e-3", 0.0010310042f)
+    ASSERT_F2S("2.882326e17", 2.8823261e17f)
 
   test "looks like pow5":
     ## These numbers have a mantissa that is the largest power of 5 that fits,
     ## and an exponent that causes the computation for q to result in 10,
     ## which is a corner case for Ryu.
-    ASSERT_F2S("6.7108864E17", int32Bits2Float(0x5D1502F9))
-    ASSERT_F2S("1.3421773E18", int32Bits2Float(0x5D9502F9))
-    ASSERT_F2S("2.6843546E18", int32Bits2Float(0x5E1502F9))
+    ASSERT_F2S("6.7108864e17", int32Bits2Float(0x5D1502F9))
+    ASSERT_F2S("1.3421773e18", int32Bits2Float(0x5D9502F9))
+    ASSERT_F2S("2.6843546e18", int32Bits2Float(0x5E1502F9))
 
   test "output length":
-    ASSERT_F2S("1E0", 1.0f) # already tested in Basic
-    ASSERT_F2S("1.2E0", 1.2f)
-    ASSERT_F2S("1.23E0", 1.23f)
-    ASSERT_F2S("1.234E0", 1.234f)
-    ASSERT_F2S("1.2345E0", 1.2345f)
-    ASSERT_F2S("1.23456E0", 1.23456f)
-    ASSERT_F2S("1.234567E0", 1.234567f)
-    ASSERT_F2S("1.2345678E0", 1.2345678f)
-    ASSERT_F2S("1.23456735E-36", 1.23456735E-36f)
+    ASSERT_F2S("1e0", 1.0f) # already tested in Basic
+    ASSERT_F2S("1.2e0", 1.2f)
+    ASSERT_F2S("1.23e0", 1.23f)
+    ASSERT_F2S("1.234e0", 1.234f)
+    ASSERT_F2S("1.2345e0", 1.2345f)
+    ASSERT_F2S("1.23456e0", 1.23456f)
+    ASSERT_F2S("1.234567e0", 1.234567f)
+    ASSERT_F2S("1.2345678e0", 1.2345678f)
+    ASSERT_F2S("1.23456735e-36", 1.23456735e-36f)

--- a/tests/tf2s.nim
+++ b/tests/tf2s.nim
@@ -32,9 +32,9 @@ suite "float to string":
     ASSERT_F2S("-0E0", -0.0)
     ASSERT_F2S("1E0", 1.0)
     ASSERT_F2S("-1E0", -1.0)
-    ASSERT_F2S("NaN", NAN)
-    ASSERT_F2S("Infinity", 0.3 / 0.0)
-    ASSERT_F2S("-Infinity", -0.3 / 0.0)
+    ASSERT_F2S("nan", NAN)
+    ASSERT_F2S("inf", 0.3 / 0.0)
+    ASSERT_F2S("-inf", -0.3 / 0.0)
 
 
   test "switch to subnormal":


### PR DESCRIPTION
/cc @disruptek 
to be consistent with:
nim, python, C, C++, go, octave, matlab

## C, C++
```nim
#include <iostream>
#include <stdio.h>

int main (int argc, char *argv[]) {
  // double x = 1.00001E25; // will print 1.00001e+25 not 1.00001E+25
  double x = 1.00001E25 / 0.0; // will print inf
  printf("%g\n", x);
  std::cout << x << std::endl;
  return 0;
}
```

## python
```py
import math
print(math.inf)
print(1.0E22) # 1e+22
print(math.inf) # inf
```
## go
```go
package main
import "fmt"
func main() {
	fmt.Println(1.00001E25) # 1.00001e+25
}
```

## octave, matlab
```
octave:5> 112.0000**12
ans =    3.8960e+24
```